### PR TITLE
Make hooks not reject my stuff

### DIFF
--- a/hooks/check-commits.sh
+++ b/hooks/check-commits.sh
@@ -29,5 +29,5 @@ do
 	git diff ${h}^..${h} > ${tmp_diff_file}
 	${HOOKS_DIR}/check-diff.py ${tmp_diff_file}
 	git cat-file commit ${h} | sed '1,/^$/d' > ${tmp_msg_file}
-	${HOOKS_DIR}/commit-msg ${tmp_msg_file}
+	${HOOKS_DIR}/check-message.py ${tmp_msg_file} server
 done

--- a/hooks/check-diff.py
+++ b/hooks/check-diff.py
@@ -10,7 +10,7 @@ def checkascii(l):
 status = 0
 filename = None
 line = None
-tabindent = False
+checktabs = False
 
 for l in open(sys.argv[1]):
   l = l.rstrip("\n")
@@ -21,7 +21,7 @@ for l in open(sys.argv[1]):
     if checkascii(filename):
       sys.stderr.write("*** Filename is non-ASCII: '{}'\n".format(filename))
       status = 1
-    tabindent = (filename.find("3rdparty") < 0) and (filename.endswith(".cpp") or filename.endswith(".hpp") or filename.endswith(".h"))
+    checktabs = (filename.find("3rdparty") < 0) and filename.endswith((".cpp", ".c", ".hpp", ".h"))
   elif l.startswith("@@"):
     line = int(l.split()[2].split(",")[0])
   elif l.startswith("+"):
@@ -32,10 +32,10 @@ for l in open(sys.argv[1]):
     if l != l.rstrip():
       sys.stderr.write("*** {}:{}: Trailing whitespace: '{}'\n".format(filename, line, l))
       status = 1
-    if not PAT_TAB.match(l):
+    if checktabs and not PAT_TAB.match(l):
       sys.stderr.write("*** {}:{}: Invalid tab usage: '{}'\n".format(filename, line, l))
       status = 1
-    if tabindent and l.startswith("  "):
+    if checktabs and l.startswith("  "):
       sys.stderr.write("*** {}:{}: Use tabs for indentation: '{}'\n".format(filename, line, l))
       status = 1
     line += 1

--- a/hooks/check-message.py
+++ b/hooks/check-message.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+
+import re, sys
+
+KEYWORDS = "(Add|Feature|Change|Remove|Codechange|Cleanup|Fix|Revert|Doc|Update|Prepare)"
+ISSUE = "#\d+"
+COMMIT = "[0-9a-f]{4,}"
+
+MSG_PAT1 = re.compile(KEYWORDS + "$")
+MSG_PAT2 = re.compile(KEYWORDS + " " + ISSUE + "$")
+MSG_PAT3 = re.compile(KEYWORDS + " " + COMMIT + "$")
+MSG_PAT4 = re.compile(COMMIT + "$")
+
+ERROR = """
+*** First line of message must match: '<keyword>( #<issue>| <commit>(, (<keyword> #<issue>|<commit>))*)?: ([<section])? <Details>'
+Valid <keyword>: """+KEYWORDS+"""
+Examples:
+  'Fix: [YAPF] Infinite loop in pathfinder.'
+  'Fix #5926: [YAPF] Infinite loop in pathfinder.'
+  'Fix 80dffae130: Warning about unsigned unary minus.
+  'Fix #6673, 99bb3a95b4: Store the map variety setting in the samegame.'
+  'Revert d9065fbfbe, Fix #5922: ClientSizeChanged is only called via WndProcGdi which already has the mutex.'
+  'Fix #1264, Fix #2037, Fix #2038, Fix #2110: Rewrite the autoreplace kernel.'
+"""
+
+is_client = sys.argv[2] = 'client'
+
+first_line = True
+for l in open(sys.argv[1]):
+  l = l.rstrip("\n")
+
+  # Skip comments on client side:
+  #   There are various ways how parts of the commit message can be ignored.
+  #   One method is by using some comment character (# by default).
+  #   Another is by using scissor lines.
+  #   We cannot tell which method is active, so we make a convenient assumption.
+  # On server side we always check the whole message, since there are no longer any comments.
+  if is_client and l.startswith("#"):
+    continue
+
+  # Check trailing whitespace
+  if l != l.rstrip():
+    sys.stderr.write("*** Message contains trailing whitespace: '{}'\n".format(l))
+    sys.exit(1)
+
+  # Check ASCII, and no control chars
+  if any(ord(c) < 32 or ord(c) > 127 for c in l):
+    sys.stderr.write("*** Message contains non-ASCII characters or tabs: '{}'\n".format(l))
+    sys.exit(1)
+
+  # Check first line
+  if first_line:
+    first_line = False
+
+    parts = l.split(": ", 1)
+    if len(parts) != 2:
+      sys.stderr.write(ERROR)
+      sys.exit(1)
+
+    prefixes = parts[0].split(", ")
+    first_prefix = True
+    for p in prefixes:
+      if (len(prefixes) == 1 and MSG_PAT1.match(p)) or MSG_PAT2.match(p) or MSG_PAT3.match(p) or (not first_prefix and MSG_PAT4.match(p)):
+        first_prefix = False
+      else:
+        sys.stderr.write(ERROR)
+        sys.exit(1)

--- a/hooks/commit-msg
+++ b/hooks/commit-msg
@@ -1,56 +1,7 @@
-#!/usr/bin/env python3
+#!/bin/sh
 
-import re, sys
+set -e
 
-KEYWORDS = "(Add|Feature|Change|Remove|Codechange|Cleanup|Fix|Revert|Doc|Update|Prepare)"
-ISSUE = "#\d+"
-COMMIT = "[0-9a-f]{4,}"
+HOOKS_DIR=${HOOKS_DIR:-${GIT_DIR}/hooks}
 
-MSG_PAT1 = re.compile(KEYWORDS + "$")
-MSG_PAT2 = re.compile(KEYWORDS + " " + ISSUE + "$")
-MSG_PAT3 = re.compile(KEYWORDS + " " + COMMIT + "$")
-MSG_PAT4 = re.compile(COMMIT + "$")
-
-ERROR = """
-*** First line of message must match: '<keyword>( #<issue>| <commit>(, (<keyword> #<issue>|<commit>))*)?: ([<section])? <Details>'
-Valid <keyword>: """+KEYWORDS+"""
-Examples:
-  'Fix: [YAPF] Infinite loop in pathfinder.'
-  'Fix #5926: [YAPF] Infinite loop in pathfinder.'
-  'Fix 80dffae130: Warning about unsigned unary minus.
-  'Fix #6673, 99bb3a95b4: Store the map variety setting in the samegame.'
-  'Revert d9065fbfbe, Fix #5922: ClientSizeChanged is only called via WndProcGdi which already has the mutex.'
-  'Fix #1264, Fix #2037, Fix #2038, Fix #2110: Rewrite the autoreplace kernel.'
-"""
-
-first_line = True
-for l in open(sys.argv[1]):
-  l = l.rstrip("\n")
-
-  # Check trailing whitespace
-  if l != l.rstrip():
-    sys.stderr.write("*** Message contains trailing whitespace: '{}'\n".format(l))
-    sys.exit(1)
-
-  # Check ASCII, and no control chars
-  if any(ord(c) < 32 or ord(c) > 127 for c in l):
-    sys.stderr.write("*** Message contains non-ASCII characters or tabs: '{}'\n".format(l))
-    sys.exit(1)
-
-  # Check first line
-  if first_line:
-    first_line = False
-
-    parts = l.split(": ", 1)
-    if len(parts) != 2:
-      sys.stderr.write(ERROR)
-      sys.exit(1)
-
-    prefixes = parts[0].split(", ")
-    first_prefix = True
-    for p in prefixes:
-      if (len(prefixes) == 1 and MSG_PAT1.match(p)) or MSG_PAT2.match(p) or MSG_PAT3.match(p) or (not first_prefix and MSG_PAT4.match(p)):
-        first_prefix = False
-      else:
-        sys.stderr.write(ERROR)
-        sys.exit(1)
+${HOOKS_DIR}/check-message.py $1 client

--- a/test/test.sh
+++ b/test/test.sh
@@ -108,7 +108,6 @@ test_commit_good "Fix abcdef, Fix #456: Commit and issue ref"
 
 cp case1.cpp case15.cpp
 git_good add case15.cpp
-test_commit_bad "#123, Fix abcdef: Issue and commit ref"
 test_commit_bad "Fix #123 abcdef: Issue and commit ref"
 test_commit_bad "Fix #123,abcdef: Issue and commit ref"
 test_commit_good "Fix #123, abcdef: Issue and commit ref"


### PR DESCRIPTION
Tabs are now only checked in .cpp, .c, .h and .hpp files.
Various scripts use tabs in "cut", "sed" etc. when dealing with field separators.

Commit messages are now checked differently on client side.
On client side commented lines "#" are ignored.
On server side there there are no comments.