### PR TITLE
Improve diagnostics from commit checker

### DIFF
--- a/hooks/check-commits.sh
+++ b/hooks/check-commits.sh
@@ -27,11 +27,11 @@ trap finish EXIT
 hashes=$(git rev-list "$1")
 for h in ${hashes}
 do
-	echo Checking $h... >&2
+	echo Checking ${h}... >&2
 	LC_ALL=C git diff ${h}^..${h} > ${tmp_diff_file}
 	${HOOKS_DIR}/check-diff.py ${tmp_diff_file} || failure=1
 	git cat-file commit ${h} | sed '1,/^$/d' > ${tmp_msg_file}
 	${HOOKS_DIR}/check-message.py ${tmp_msg_file} server || failure=1
 done
 
-return $failure
+return ${failure}

--- a/hooks/check-commits.sh
+++ b/hooks/check-commits.sh
@@ -24,6 +24,8 @@ finish() {
 }
 trap finish EXIT
 
+echo "::add-matcher::${HOOKS_DIR}/check-diff-matcher.json"
+
 hashes=$(git rev-list "$1")
 for h in ${hashes}
 do
@@ -33,5 +35,7 @@ do
 	git cat-file commit ${h} | sed '1,/^$/d' > ${tmp_msg_file}
 	${HOOKS_DIR}/check-message.py ${tmp_msg_file} server || failure=1
 done
+
+echo "::remove-matcher owner=check-diff::"
 
 return ${failure}

--- a/hooks/check-commits.sh
+++ b/hooks/check-commits.sh
@@ -24,8 +24,10 @@ finish() {
 }
 trap finish EXIT
 
-echo "::add-matcher::${HOOKS_DIR}/check-diff-matcher.json"
-echo "::add-matcher::${HOOKS_DIR}/check-message-matcher.json"
+if [ ${GITHUB_ACTIONS} ]; then
+	echo "::add-matcher::${HOOKS_DIR}/check-diff-matcher.json"
+	echo "::add-matcher::${HOOKS_DIR}/check-message-matcher.json"
+fi
 
 hashes=$(git rev-list "$1")
 for h in ${hashes}
@@ -37,7 +39,9 @@ do
 	${HOOKS_DIR}/check-message.py ${tmp_msg_file} server || failure=1
 done
 
-echo "::remove-matcher owner=check-diff::"
-echo "::remove-matcher owner=check-message::"
+if [ ${GITHUB_ACTIONS} ]; then
+	echo "::remove-matcher owner=check-diff::"
+	echo "::remove-matcher owner=check-message::"
+fi
 
 return ${failure}

--- a/hooks/check-commits.sh
+++ b/hooks/check-commits.sh
@@ -25,6 +25,7 @@ finish() {
 trap finish EXIT
 
 echo "::add-matcher::${HOOKS_DIR}/check-diff-matcher.json"
+echo "::add-matcher::${HOOKS_DIR}/check-message-matcher.json"
 
 hashes=$(git rev-list "$1")
 for h in ${hashes}
@@ -37,5 +38,6 @@ do
 done
 
 echo "::remove-matcher owner=check-diff::"
+echo "::remove-matcher owner=check-message::"
 
 return ${failure}

--- a/hooks/check-commits.sh
+++ b/hooks/check-commits.sh
@@ -27,7 +27,7 @@ trap finish EXIT
 hashes=$(git rev-list "$1")
 for h in ${hashes}
 do
-	echo Checking ${h}... >&2
+	git log ${h}^..${h} --format='%n>>> %h >>> %s'
 	LC_ALL=C git diff ${h}^..${h} > ${tmp_diff_file}
 	${HOOKS_DIR}/check-diff.py ${tmp_diff_file} || failure=1
 	git cat-file commit ${h} | sed '1,/^$/d' > ${tmp_msg_file}

--- a/hooks/check-commits.sh
+++ b/hooks/check-commits.sh
@@ -17,6 +17,7 @@ fi
 HOOKS_DIR=${HOOKS_DIR:-${GIT_DIR}/hooks}
 tmp_msg_file=$(mktemp)
 tmp_diff_file=$(mktemp)
+failure=0
 
 finish() {
 	rm -f ${tmp_msg_file} ${tmp_diff_file}
@@ -26,8 +27,11 @@ trap finish EXIT
 hashes=$(git rev-list "$1")
 for h in ${hashes}
 do
+	echo Checking $h... >&2
 	LC_ALL=C git diff ${h}^..${h} > ${tmp_diff_file}
-	${HOOKS_DIR}/check-diff.py ${tmp_diff_file}
+	${HOOKS_DIR}/check-diff.py ${tmp_diff_file} || failure=1
 	git cat-file commit ${h} | sed '1,/^$/d' > ${tmp_msg_file}
-	${HOOKS_DIR}/check-message.py ${tmp_msg_file} server
+	${HOOKS_DIR}/check-message.py ${tmp_msg_file} server || failure=1
 done
+
+return $failure

--- a/hooks/check-diff-matcher.json
+++ b/hooks/check-diff-matcher.json
@@ -1,0 +1,16 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "check-diff",
+            "pattern": [
+                {
+                    "regexp": "^\\*{3}\\s./(.+):(\\d+):\\s(.+):\\s(.+)$",
+                    "file": 1,
+                    "line": 2,
+                    "message": 3,
+                    "code": 4
+                }
+            ]
+        }
+    ]
+}

--- a/hooks/check-message-matcher.json
+++ b/hooks/check-message-matcher.json
@@ -1,0 +1,13 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "check-message",
+            "pattern": [
+                {
+                    "regexp": "^\\*{3}\\s(First.+)$",
+                    "message": 1,
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Instead of failing on the first problem, and then not identifying the commit that caused it, print commit ids as they are checked, and continue checking after finding problems. This should make it easier and faster to correct problems with commit messages and code formatting.