### PR TITLE
Change: Preprocessor commands put the tab into the first column. Then follow regular tab indentation.

### DIFF
--- a/hooks/check-diff.py
+++ b/hooks/check-diff.py
@@ -2,7 +2,7 @@
 
 import re, sys
 
-PAT_TAB = re.compile("\t*[^\t]*$")
+PAT_TAB = re.compile("#?\t*[^\t]*$")
 
 def checkascii(l):
   return any((ord(c) < 32 or ord(c) > 127) and c != '\t' for c in l)
@@ -34,6 +34,9 @@ for l in open(sys.argv[1], encoding="utf-8"):
       status = 1
     if is_source and not PAT_TAB.match(l):
       sys.stderr.write("*** {}:{}: Invalid tab usage: '{}'\n".format(filename, line, l))
+      status = 1
+    if is_source and (l.find("\t#") >= 0):
+      sys.stderr.write("*** {}:{}: Preprocessor hash is put into the first column, before the tab indentation: '{}'\n".format(filename, line, l))
       status = 1
     if is_source and l.startswith("  "):
       sys.stderr.write("*** {}:{}: Use tabs for indentation: '{}'\n".format(filename, line, l))

--- a/test/cases/case7.cpp
+++ b/test/cases/case7.cpp
@@ -3,7 +3,7 @@
  */
 
 #ifdef FOO
-#	include <bar>
+	#include <bar>
 #endif
 
 int foo()

--- a/test/test.sh
+++ b/test/test.sh
@@ -147,6 +147,10 @@ git_good add case6.cpp
 test_commit_bad "Add: NL at EOF"
 git_good reset case6.cpp
 
+git_good add case7.cpp
+test_commit_bad "Add: Preprocessor hash indented"
+git_good reset case7.cpp
+
 git_good push
 
 # setup badguy


### PR DESCRIPTION
This is according to
https://wiki.openttd.org/Coding_style#Other_important_rules

Existing code is mixed.
Stuff like
```C
#ifdef foo
    #include <bar>
#endif
```
will now get rejected.

Valid would be:
```C
#ifdef foo
#    include <bar>
#endif
```
