### PR TITLE
Fix: GIT_DIR is no longer set in git >= 2.18.0

### DIFF
--- a/hooks/commit-msg
+++ b/hooks/commit-msg
@@ -2,6 +2,8 @@
 
 set -e
 
+GIT_DIR=${GIT_DIR:-$(git rev-parse --git-dir)}
+
 HOOKS_DIR=${HOOKS_DIR:-${GIT_DIR}/hooks}
 
 ${HOOKS_DIR}/check-message.py $1 client

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -5,6 +5,8 @@
 
 set -e
 
+GIT_DIR=${GIT_DIR:-$(git rev-parse --git-dir)}
+
 # --- Safety check
 if [ -z "${GIT_DIR}" ]; then
 	echo "Don't run this script from the command line." >&2

--- a/hooks/update
+++ b/hooks/update
@@ -13,6 +13,8 @@ refname="$1"
 oldrev="$2"
 newrev="$3"
 
+GIT_DIR=${GIT_DIR:-$(git rev-parse --git-dir)}
+
 # --- Safety check
 if [ -z "${GIT_DIR}" ]; then
 	echo "Don't run this script from the command line." >&2


### PR DESCRIPTION
Use `git rev-parse --git-dir` as fallback.
Related discussion:
https://public-inbox.org/git/20180826004150.GA31168@sigill.intra.peff.net/t/