### PR TITLE
Improve commit checker

### DIFF
--- a/hooks/check-commits.sh
+++ b/hooks/check-commits.sh
@@ -21,6 +21,7 @@ tmp_diff_file=$(mktemp)
 hashes=$(git rev-list "$1")
 for h in ${hashes}
 do
+	git log ${h}^..${h} --format="%n>>> %h %s <<<"
 	LC_ALL=C git diff ${h}^..${h} > ${tmp_diff_file}
 	${HOOKS_DIR}/check-diff.py ${tmp_diff_file} || true
 	git cat-file commit ${h} | sed '1,/^$/d' > ${tmp_msg_file}

--- a/hooks/check-commits.sh
+++ b/hooks/check-commits.sh
@@ -18,16 +18,13 @@ HOOKS_DIR=${HOOKS_DIR:-${GIT_DIR}/hooks}
 tmp_msg_file=$(mktemp)
 tmp_diff_file=$(mktemp)
 
-finish() {
-	rm -f ${tmp_msg_file} ${tmp_diff_file}
-}
-trap finish EXIT
-
 hashes=$(git rev-list "$1")
 for h in ${hashes}
 do
 	LC_ALL=C git diff ${h}^..${h} > ${tmp_diff_file}
-	${HOOKS_DIR}/check-diff.py ${tmp_diff_file}
+	${HOOKS_DIR}/check-diff.py ${tmp_diff_file} || true
 	git cat-file commit ${h} | sed '1,/^$/d' > ${tmp_msg_file}
-	${HOOKS_DIR}/check-message.py ${tmp_msg_file} server
+	${HOOKS_DIR}/check-message.py ${tmp_msg_file} server || true
 done
+
+rm -f ${tmp_msg_file} ${tmp_diff_file}


### PR DESCRIPTION
When pull-request commits are checked I think it's better to check the diff and the message for all commits, that way the contributor will be able to fix everything at once.
Also display the commit being checked to easily find where the error is. The format used will output like
```

>>> c8408ff Change: Show which commit is being checked <<<
<errors if any>

>>> dc5255b Change: Always do all checks for all commits <<<
<errors if any>
```