### PR TITLE
Fix: Check ObjC files as other source files

### DIFF
--- a/hooks/check-diff.py
+++ b/hooks/check-diff.py
@@ -23,7 +23,7 @@ for l in open(sys.argv[1], encoding="utf-8"):
     if checkascii(filename):
       sys.stderr.write("*** Filename is non-ASCII: '{}'\n".format(filename))
       status = 1
-    is_source = (filename.find("3rdparty") < 0) and filename.endswith((".cpp", ".c", ".hpp", ".h"))
+    is_source = (filename.find("3rdparty") < 0) and filename.endswith((".cpp", ".c", ".hpp", ".h", ".mm"))
   elif l.startswith("@@"):
     line = int(l.split()[2].split(",")[0])
     lastline = None


### PR DESCRIPTION
~~NFO files used for nml regression check can contain trailing whitespaces, and commit checker doesn't know that. This PR disable trailing whitespaces checks for these files.~~

Also, while reading the diff checker, I noticed ObjC source files of OpenTTD were skipped for most code style checks, so I fixed it.