### PR TITLE
Add: allow "Upgrade" keyword in commit messages

### DIFF
--- a/hooks/check-message.py
+++ b/hooks/check-message.py
@@ -2,7 +2,7 @@
 
 import re, sys
 
-KEYWORDS = "(Add|Feature|Change|Remove|Codechange|Cleanup|Fix|Revert|Doc|Update|Prepare)"
+KEYWORDS = "(Add|Feature|Change|Remove|Codechange|Cleanup|Fix|Revert|Doc|Update|Upgrade|Prepare)"
 ISSUE = "#\d+"
 COMMIT = "[0-9a-f]{4,}"
 


### PR DESCRIPTION
Dependabot wants to use it for its PRs, and it is not wrong.

We normally use "update" for it, but that is kinda wrong, as it is actually upgrading.

So this would really help out not having to change the commit message every time to make the commit-checker happy.