### PR TITLE
Fix: Use raw string for regex with escape sequences.

### DIFF
--- a/hooks/check-message.py
+++ b/hooks/check-message.py
@@ -3,7 +3,7 @@
 import re, sys
 
 KEYWORDS = "(Add|Feature|Change|Remove|Codechange|Codefix|Cleanup|Fix|Revert|Doc|Update|Upgrade|Prepare)"
-ISSUE = "#\d+"
+ISSUE = r"#\d+"
 COMMIT = "[0-9a-f]{4,}"
 
 MSG_PAT1 = re.compile(KEYWORDS + "$")


### PR DESCRIPTION
```
/home/runner/work/_actions/OpenTTD/OpenTTD-git-hooks/main/hooks/check-message.py:6: SyntaxWarning: invalid escape sequence '\d'
  ISSUE = "#\d+"
```